### PR TITLE
Fix error cases caused by `errorCb` not existing.

### DIFF
--- a/shared/js/fxa_iac_client.js
+++ b/shared/js/fxa_iac_client.js
@@ -39,11 +39,13 @@ var FxAccountsIACHelper = function FxAccountsIACHelper() {
   // to a single manifest.
   var sendMessage = function sendMessage(message, successCb, errorCb) {
     getSelf(function onApp(app) {
+      if (!errorCb || typeof errorCb !== 'function') {
+        errorCb = function() {};
+      }
+
       app.connect(CONNECTION_STRING, rules).then(function(ports) {
         if (!ports || ports.length !== 1) {
-          if (errorCb && typeof(errorCb) === 'function') {
-            errorCb();
-          }
+          errorCb();
           return;
         }
 


### PR DESCRIPTION
Create a dummy function for the several cases in `sendMessage` in which `errorCb` is assumed to exist.
